### PR TITLE
Add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mediapipe >=0.8.1
+opencv-python >= 3.4.2
+tensorflow >= 2.3.0
+tf-nightly >= 2.5.0-dev
+scikit-learn >= 0.23.2 
+matplotlib >= 3.3.2


### PR DESCRIPTION
Adds a simple requirements file. (Fixes #6 ) 

Allows you to quickly install the required python packages with 
```
python3 -m pip install -r requirements.txt 

```